### PR TITLE
Bypass pow2 check in nextInt when possible

### DIFF
--- a/generator.cpp
+++ b/generator.cpp
@@ -25,9 +25,22 @@ bool generator::ChunkGenerator::isValidTreeSpot(int treeX, int treeZ, bool first
 
 void generator::ChunkGenerator::generateLeafPattern(random_math::JavaRand& random, bool *out)
 {
-    for (int32_t i = 0; i < 16; i++) {
-        out[i] = random.nextInt(2) != 0;
-    }
+    out[0] = random.nextInt(2) != 0;
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    out[4] = random.nextInt(2) != 0;
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
+    random.nextInt(2);
 }
 
 int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX)
@@ -40,7 +53,7 @@ int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int
         int32_t treeZ = random.nextInt(16);
         int32_t height = random.nextInt(3) + 4;
         if (!treesFound[0] && treeX == waterfallX + TREE1_X && treeZ == TREE1_Z && height == TREE1_HEIGHT) {
-            generator::ChunkGenerator::generateLeafPattern(random, leafPattern);
+            generateLeafPattern(random, leafPattern);
             foundTreeCount++;
             treesFound[0] = true;
         } else if (!treesFound[1] && treeX == waterfallX + TREE2_X && treeZ == TREE2_Z && height == TREE2_HEIGHT) {

--- a/generator.cpp
+++ b/generator.cpp
@@ -25,22 +25,22 @@ bool generator::ChunkGenerator::isValidTreeSpot(int treeX, int treeZ, bool first
 
 void generator::ChunkGenerator::generateLeafPattern(random_math::JavaRand& random, bool *out)
 {
-    out[0] = random.nextInt(2) != 0;
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    out[4] = random.nextInt(2) != 0;
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
-    random.nextInt(2);
+    out[0] = random.nextIntPow2Unchecked(2) != 0;
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    out[4] = random.nextIntPow2Unchecked(2) != 0;
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
+    random.nextIntPow2Unchecked(2);
 }
 
 int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX)
@@ -49,8 +49,8 @@ int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int
     bool leafPattern[16];
     int8_t foundTreeCount = 0;
     for (int i = 0; i <= maxTreeCount; ++i) {
-        int32_t treeX = random.nextInt(16);
-        int32_t treeZ = random.nextInt(16);
+        int32_t treeX = random.nextIntPow2Unchecked(16);
+        int32_t treeZ = random.nextIntPow2Unchecked(16);
         int32_t height = random.nextInt(3) + 4;
         if (!treesFound[0] && treeX == waterfallX + TREE1_X && treeZ == TREE1_Z && height == TREE1_HEIGHT) {
             generateLeafPattern(random, leafPattern);

--- a/random.cpp
+++ b/random.cpp
@@ -74,7 +74,7 @@ uint32_t random_math::JavaRand::next(int32_t bits)
 uint32_t random_math::JavaRand::nextInt(int32_t bound)
 {
     if (bound <= 0) {
-        throw std::invalid_argument("Bound must be positive");
+	abort();
     }
 
     if ((bound & -bound) == bound) {
@@ -88,4 +88,8 @@ uint32_t random_math::JavaRand::nextInt(int32_t bound)
         value = bits % bound;
     } while (bits - value + (bound - 1) < 0);
     return value;
+}
+
+uint32_t random_math::JavaRand::nextIntPow2Unchecked(int32_t bound) {
+    return (int32_t) ((bound * (int64_t) this->next(31)) >> 31);
 }

--- a/random.h
+++ b/random.h
@@ -34,6 +34,8 @@ namespace random_math
         void setSeed(int64_t seed, bool scramble = true);
         uint32_t next(int32_t bits);
         uint32_t nextInt(int32_t bound);
+        /* bound must be a positive power of 2 */
+        uint32_t nextIntPow2Unchecked(int32_t bound);
     };
 
 }


### PR DESCRIPTION
Add a new RNG function, nextIntPow2Unchecked, which skips all the safety checks in nextInt.

In local testing, this reduced the self time of nextInt from **38.14%** (12.81% next + 25.33% nextInt) to **28.03%** (16.00% next + 8.26% nextUnchecked  + 3.77% nextInt).

Extra verification run on patch-2:
13.10% next + 25.26% nextInt