### PR TITLE
Remove unnecessary checks and leaf generation.

### DIFF
--- a/generator.cpp
+++ b/generator.cpp
@@ -45,37 +45,17 @@ void generator::ChunkGenerator::generateLeafPattern(random_math::JavaRand& rando
 
 void generator::ChunkGenerator::ignoreLeafPattern(random_math::JavaRand& random)
 {
-    for (int i = 0; i < 4; i++) {
-        random.ignoreNext();
-        random.ignoreNext();
-        random.ignoreNext();
-        random.ignoreNext();
-    }
+    random.advance(advance_16);
 }
 
 bool generator::ChunkGenerator::leafPatternNot0And4(random_math::JavaRand& random)
 {
     bool _0 = random.nextIntPow2Unchecked(2) != 0;
-
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
+    random.advance(advance_3);
 
     bool _4 = random.nextIntPow2Unchecked(2) != 0;
+    random.advance(advance_11);
 
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
-
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
-
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
-    random.ignoreNext();
 
     return !_0 && _4;
 }
@@ -124,6 +104,12 @@ bool generator::ChunkGenerator::populate(int64_t chunkSeed, int waterfallX)
 
 void generator::ChunkGenerator::init()
 {
+    generator::ChunkGenerator::advance_3 = random_math::JavaRand::lcg.combine(3);
+    generator::ChunkGenerator::advance_11 = random_math::JavaRand::lcg.combine(11);
+    generator::ChunkGenerator::advance_16 = random_math::JavaRand::lcg.combine(16);
     generator::ChunkGenerator::advance_3759 = random_math::JavaRand::lcg.combine(3759);
 }
+random_math::LCG generator::ChunkGenerator::advance_3(1, 1, 1);
+random_math::LCG generator::ChunkGenerator::advance_11(1, 1, 1);
+random_math::LCG generator::ChunkGenerator::advance_16(1, 1, 1);
 random_math::LCG generator::ChunkGenerator::advance_3759(1, 1, 1);

--- a/generator.cpp
+++ b/generator.cpp
@@ -43,6 +43,16 @@ void generator::ChunkGenerator::generateLeafPattern(random_math::JavaRand& rando
     out[15] = random.nextIntPow2Unchecked(2) != 0;
 }
 
+void generator::ChunkGenerator::ignoreLeafPattern(random_math::JavaRand& random)
+{
+    for (int i = 0; i < 4; i++) {
+        random.ignoreNext();
+        random.ignoreNext();
+        random.ignoreNext();
+        random.ignoreNext();
+    }
+}
+
 int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX)
 {
     bool treesFound[2] = {false, false};
@@ -53,7 +63,7 @@ int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int
         int32_t treeZ = random.nextIntPow2Unchecked(16);
         int32_t height = random.nextInt(3) + 4;
         if (!treesFound[0] && treeX == waterfallX + TREE1_X && treeZ == TREE1_Z && height == TREE1_HEIGHT) {
-            generateLeafPattern(random, leafPattern);
+            ignoreLeafPattern(random);
             foundTreeCount++;
             treesFound[0] = true;
         } else if (!treesFound[1] && treeX == waterfallX + TREE2_X && treeZ == TREE2_Z && height == TREE2_HEIGHT) {

--- a/generator.cpp
+++ b/generator.cpp
@@ -76,7 +76,7 @@ int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int
 
 bool generator::ChunkGenerator::populate(int64_t chunkSeed, int waterfallX)
 {
-    random_math::JavaRand random(advance_3759.next(chunkSeed), false);
+    random_math::JavaRand random(advance_3759.nextMaskableUnchecked(chunkSeed), false);
 
     int32_t maxBaseTreeCount = 12;
     if (random.nextInt(10) == 0)

--- a/generator.cpp
+++ b/generator.cpp
@@ -53,6 +53,33 @@ void generator::ChunkGenerator::ignoreLeafPattern(random_math::JavaRand& random)
     }
 }
 
+bool generator::ChunkGenerator::leafPatternNot0And4(random_math::JavaRand& random)
+{
+    bool _0 = random.nextIntPow2Unchecked(2) != 0;
+
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+
+    bool _4 = random.nextIntPow2Unchecked(2) != 0;
+
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+    random.ignoreNext();
+
+    return !_0 && _4;
+}
+
 int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX)
 {
     bool treesFound[2] = {false, false};
@@ -67,8 +94,7 @@ int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int
             foundTreeCount++;
             treesFound[0] = true;
         } else if (!treesFound[1] && treeX == waterfallX + TREE2_X && treeZ == TREE2_Z && height == TREE2_HEIGHT) {
-            generateLeafPattern(random, leafPattern);
-            if (!leafPattern[0] && leafPattern[4]) {
+            if (leafPatternNot0And4(random)) {
                 foundTreeCount++;
                 treesFound[1] = true;
             } else {

--- a/generator.h
+++ b/generator.h
@@ -13,6 +13,7 @@ namespace generator
         static bool isValidTreeSpot(int treeX, int treeZ, bool firstTreeFound, bool secondTreeFound, int waterfallX);
         static void generateLeafPattern(random_math::JavaRand& random, bool *out);
         static void ignoreLeafPattern(random_math::JavaRand& random);
+        static bool leafPatternNot0And4(random_math::JavaRand& random);
         static int32_t checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX);
     public:
         static void init();

--- a/generator.h
+++ b/generator.h
@@ -17,6 +17,9 @@ namespace generator
         static int32_t checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX);
     public:
         static void init();
+        static random_math::LCG advance_3;
+        static random_math::LCG advance_11;
+        static random_math::LCG advance_16;
         static random_math::LCG advance_3759;
         static bool populate(int64_t chunkSeed, int waterfallX);
 

--- a/generator.h
+++ b/generator.h
@@ -12,6 +12,7 @@ namespace generator
     private:
         static bool isValidTreeSpot(int treeX, int treeZ, bool firstTreeFound, bool secondTreeFound, int waterfallX);
         static void generateLeafPattern(random_math::JavaRand& random, bool *out);
+        static void ignoreLeafPattern(random_math::JavaRand& random);
         static int32_t checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX);
     public:
         static void init();

--- a/random.cpp
+++ b/random.cpp
@@ -70,6 +70,10 @@ void random_math::JavaRand::setSeed(int64_t seed, bool scramble)
     this->seed &= lcg.modulo - 1;
 }
 
+void random_math::JavaRand::ignoreNext() {
+    this->seed = lcg.nextMaskableUnchecked(this->seed);
+}
+
 uint32_t random_math::JavaRand::next(int32_t bits)
 {
     this->seed = lcg.nextMaskableUnchecked(this->seed);

--- a/random.cpp
+++ b/random.cpp
@@ -12,6 +12,11 @@ int64_t random_math::LCG::next(int64_t seed)
     return (seed * this->multiplier + this->addend) % this->modulo;
 }
 
+int64_t random_math::LCG::nextMaskableUnchecked(int64_t seed)
+{
+    return (seed * this->multiplier + this->addend) & (this->modulo - 1);
+}
+
 random_math::LCG random_math::LCG::combine(int64_t steps)
 {
     int64_t mul = 1;
@@ -67,7 +72,7 @@ void random_math::JavaRand::setSeed(int64_t seed, bool scramble)
 
 uint32_t random_math::JavaRand::next(int32_t bits)
 {
-    this->seed = lcg.next(this->seed);
+    this->seed = lcg.nextMaskableUnchecked(this->seed);
     return (uint32_t) (((uint64_t)this->seed) >> (48 - bits));
 }
 

--- a/random.cpp
+++ b/random.cpp
@@ -64,6 +64,11 @@ uint64_t random_math::JavaRand::getSeed()
     return this->seed;
 }
 
+void random_math::JavaRand::advance(random_math::LCG lcg) 
+{
+    this->seed = lcg.next(this->seed);
+}
+
 void random_math::JavaRand::setSeed(int64_t seed, bool scramble)
 {
     this->seed = seed ^ (scramble ? lcg.multiplier : 0ULL);

--- a/random.h
+++ b/random.h
@@ -33,6 +33,7 @@ namespace random_math
         explicit JavaRand(long seed, bool scramble = true);
         uint64_t getSeed();
         void setSeed(int64_t seed, bool scramble = true);
+        void ignoreNext();
         uint32_t next(int32_t bits);
         uint32_t nextInt(int32_t bound);
         /* bound must be a positive power of 2 */

--- a/random.h
+++ b/random.h
@@ -33,6 +33,7 @@ namespace random_math
         explicit JavaRand(long seed, bool scramble = true);
         uint64_t getSeed();
         void setSeed(int64_t seed, bool scramble = true);
+        void advance(LCG lcg);
         void ignoreNext();
         uint32_t next(int32_t bits);
         uint32_t nextInt(int32_t bound);

--- a/random.h
+++ b/random.h
@@ -17,6 +17,7 @@ namespace random_math
         LCG(int64_t multiplier, int64_t addend, int64_t modulo, bool maskable = true);
 
         int64_t next(int64_t seed);
+        int64_t nextMaskableUnchecked(int64_t seed);
 
         LCG combine(int64_t steps);
 


### PR DESCRIPTION
The LCG modulo is maskable much of the time, so an unchecked `next` can be used. Also, not every leaf generation value is used, so these can be replaced with a `next`.