### PR TITLE
Removed unnecessary state changes to RNG after last next() call

### DIFF
--- a/generator.cpp
+++ b/generator.cpp
@@ -50,14 +50,18 @@ void generator::ChunkGenerator::ignoreLeafPattern(random_math::JavaRand& random)
 
 bool generator::ChunkGenerator::leafPatternNot0And4(random_math::JavaRand& random)
 {
-    bool _0 = random.nextIntPow2Unchecked(2) != 0;
+    if (random.nextIntPow2Unchecked(2) != 0) {
+        return false;
+    }
+    
     random.advance(advance_3);
 
-    bool _4 = random.nextIntPow2Unchecked(2) != 0;
-    random.advance(advance_11);
+    if (random.nextIntPow2Unchecked(2)) {
+        random.advance(advance_11);
+        return true;
+    }
 
-
-    return !_0 && _4;
+    return false;
 }
 
 int32_t generator::ChunkGenerator::checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX)

--- a/generator.h
+++ b/generator.h
@@ -13,6 +13,7 @@ namespace generator
         static bool isValidTreeSpot(int treeX, int treeZ, bool firstTreeFound, bool secondTreeFound, int waterfallX);
         static void generateLeafPattern(random_math::JavaRand& random, bool *out);
         static void ignoreLeafPattern(random_math::JavaRand& random);
+        /* When false is returned, the RNG will be in an invalid state */
         static bool leafPatternNot0And4(random_math::JavaRand& random);
         static int32_t checkTrees(random_math::JavaRand& random, int32_t maxTreeCount, int waterfallX);
     public:


### PR DESCRIPTION
I `leafPatternNot0And4` returns false, the RNG is no longer needed, so there is no need to return it into a correct state.